### PR TITLE
Provide build support on YOCTO kirkstone based SDKs

### DIFF
--- a/src/3rdparty/catch2/include/catch2/catch.hpp
+++ b/src/3rdparty/catch2/include/catch2/catch.hpp
@@ -10450,7 +10450,11 @@ namespace Catch {
 
     // 32kb for the alternate stack seems to be sufficient. However, this value
     // is experimentally determined, so that's not guaranteed.
-    static constexpr std::size_t sigStackSize = 32768 >= MINSIGSTKSZ ? 32768 : MINSIGSTKSZ;
+    //static constexpr std::size_t sigStackSize = 32768 >= MINSIGSTKSZ ? 32768 : MINSIGSTKSZ;
+    // Since glibc 2.33.9000 MINSIGSTKSZ is no more a constant.  So,
+    // let's hardwire this for now as suggested by
+    // https://github.com/catchorg/Catch2/issues/2178.
+    static constexpr std::size_t sigStackSize = 32768;
 
     static SignalDefs signalDefs[] = {
         { SIGINT,  "SIGINT - Terminal interrupt signal" },

--- a/src/lib/lan7430conf/CMakeLists.txt
+++ b/src/lib/lan7430conf/CMakeLists.txt
@@ -18,7 +18,7 @@ add_definitions(-DSPDLOG_HEADER_ONLY) # tell spdlog to be used as header only
 add_library( ${PROJECT_NAME} SHARED ${SOURCES} ${HEADERS})
 
 include(GenerateExportHeader)
-set(PROJECT_EXPORT_FILE_NAME lan7430conf/${PROJECT_NAME}_export.h)
+set(PROJECT_EXPORT_FILE_NAME ${CMAKE_CURRENT_BINARY_DIR}/lan7430conf/${PROJECT_NAME}_export.h)
 generate_export_header(${PROJECT_NAME}
     EXPORT_FILE_NAME ${PROJECT_EXPORT_FILE_NAME}
 )

--- a/src/lib/lan7430conf/CMakeLists.txt
+++ b/src/lib/lan7430conf/CMakeLists.txt
@@ -16,9 +16,11 @@ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 add_definitions(-DSPDLOG_HEADER_ONLY) # tell spdlog to be used as header only
 add_library( ${PROJECT_NAME} SHARED ${SOURCES} ${HEADERS})
+
 include(GenerateExportHeader)
+set(PROJECT_EXPORT_FILE_NAME lan7430conf/${PROJECT_NAME}_export.h)
 generate_export_header(${PROJECT_NAME}
-    EXPORT_FILE_NAME lan7430conf/${PROJECT_NAME}_export.h
+    EXPORT_FILE_NAME ${PROJECT_EXPORT_FILE_NAME}
 )
 target_link_libraries(${PROJECT_NAME}
     PRIVATE
@@ -36,6 +38,16 @@ target_include_directories(${PROJECT_NAME}
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
 
+set(PUBLIC_HEADERS
+    ${HEADERS}
+    ${PROJECT_EXPORT_FILE_NAME}
+)
+
+set_target_properties(${PROJECT_NAME}
+    PROPERTIES
+    PUBLIC_HEADER "${PUBLIC_HEADERS}"
+)
+
 #------------------
 # Tests
 #------------------
@@ -43,13 +55,18 @@ if(ENABLE_TESTING)
   add_subdirectory(test)
 endif()
 
+set(PROJECT_CMAKE_CONFIG_FILE_NAME "${PROJECT_NAME}Config.cmake")
+set(PROJECT_CMAKE_EXPORT_NAME "${PROJECT_NAME}Config")
+
+export(TARGETS ${PROJECT_NAME}
+    NAMESPACE Lan7430conf::
+    FILE ${PROJECT_CMAKE_CONFIG_FILE_NAME}
+)
+
 install(TARGETS ${PROJECT_NAME}
-    EXPORT ${PROJECT_NAME}
+    EXPORT ${PROJECT_CMAKE_EXPORT_NAME}
     RUNTIME DESTINATION ${_bin}
     LIBRARY DESTINATION ${_lib}
     ARCHIVE DESTINATION ${_lib}
     PUBLIC_HEADER DESTINATION ${_include}/lan7430conf
-)
-install(FILES
-    ${PROJECT_BINARY_DIR}/lan7430conf/${PROJECT_NAME}_export.h DESTINATION ${_include}/lan7430conf
 )

--- a/src/lib/lan7430conf/include/lan7430conf/lan7430conf.hpp
+++ b/src/lib/lan7430conf/include/lan7430conf/lan7430conf.hpp
@@ -15,6 +15,7 @@
 #include "lan7430conf/lan7430-config-lib_export.h"
 
 #include <array>
+#include <string>
 
 enum class EEPROM_MAGIC
 {


### PR DESCRIPTION
This fixes two smaller issues which arised by the usage of the GCC and glibc shipped with the Yocto kirkstone branch