### PR TITLE
Build liblan7430-config-lib.so as a versioned shared library

### DIFF
--- a/src/lib/lan7430conf/CMakeLists.txt
+++ b/src/lib/lan7430conf/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(lan7430-config-lib LANGUAGES CXX VERSION 0.0.1)
+project(lan7430-config-lib LANGUAGES CXX VERSION 1.1.0)
 
 set(HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/include/lan7430conf/lan7430conf.hpp
@@ -46,6 +46,8 @@ set(PUBLIC_HEADERS
 set_target_properties(${PROJECT_NAME}
     PROPERTIES
     PUBLIC_HEADER "${PUBLIC_HEADERS}"
+    VERSION ${PROJECT_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR}
 )
 
 #------------------


### PR DESCRIPTION
Add VERSION and SOVERSION to set_target_properties() in the library CMakeLists.txt so that liblan7430-config-lib.so is a symbolic link to a versioned .so library file.

This will allow multiple versions of the library to be installed on the system to support API revisions. Also, fixes build errors with the Yocto Project & bitbake which require versioned .so library files.

Was:

build/lib/
└── liblan7430-config-lib.so

Now:

build/lib/
├── liblan7430-config-lib.so -> liblan7430-config-lib.so.1 ├── liblan7430-config-lib.so.1 -> liblan7430-config-lib.so.1.1.0 └── liblan7430-config-lib.so.1.1.0