### PR TITLE
Fix installation of project cmake config file

### DIFF
--- a/src/lib/lan7430conf/CMakeLists.txt
+++ b/src/lib/lan7430conf/CMakeLists.txt
@@ -72,3 +72,8 @@ install(TARGETS ${PROJECT_NAME}
     ARCHIVE DESTINATION ${_lib}
     PUBLIC_HEADER DESTINATION ${_include}/lan7430conf
 )
+
+install(EXPORT ${PROJECT_CMAKE_EXPORT_NAME}
+       DESTINATION "${_lib}/cmake/${PROJECT_NAME}"
+       NAMESPACE lan7430conf::
+)


### PR DESCRIPTION
This will install below files.

image/usr/lib/cmake/
└── lan7430-config-lib
    ├── lan7430-config-libConfig.cmake
    └── lan7430-config-libConfig-noconfig.cmake