### PR TITLE
Replace boost dependencies

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,18 @@
+FROM mcr.microsoft.com/devcontainers/cpp:1-ubuntu-22.04
+
+ARG REINSTALL_CMAKE_VERSION_FROM_SOURCE="none"
+
+# Optionally install the cmake for vcpkg
+COPY ./reinstall-cmake.sh /tmp/
+
+RUN if [ "${REINSTALL_CMAKE_VERSION_FROM_SOURCE}" != "none" ]; then \
+        chmod +x /tmp/reinstall-cmake.sh && /tmp/reinstall-cmake.sh ${REINSTALL_CMAKE_VERSION_FROM_SOURCE}; \
+    fi \
+    && rm -f /tmp/reinstall-cmake.sh
+
+# [Optional] Uncomment this section to install additional vcpkg ports.
+# RUN su vscode -c "${VCPKG_ROOT}/vcpkg install <your-port-name-here>"
+
+# [Optional] Uncomment this section to install additional packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,38 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/cpp
+{
+	"name": "C++",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"features": {
+		"ghcr.io/devcontainers-contrib/features/pre-commit:2": {
+			"version": "latest"
+		},
+		"ghcr.io/msclock/features/vcpkg:1": {
+			"username": "automatic",
+			"vcpkgversion": "latest",
+			"vcpkgroot": "/usr/local/vcpkg",
+			"vcpkgdownload": "/usr/local/vcpkg-downloads"
+		},
+		"ghcr.io/devcontainers-contrib/features/actions-runner-noruntime:1": {
+			"version": "latest",
+			"dotnetVersion": "latest"
+		}
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "gcc -v",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/reinstall-cmake.sh
+++ b/.devcontainer/reinstall-cmake.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+#
+set -e
+
+CMAKE_VERSION=${1:-"none"}
+
+if [ "${CMAKE_VERSION}" = "none" ]; then
+    echo "No CMake version specified, skipping CMake reinstallation"
+    exit 0
+fi
+
+# Cleanup temporary directory and associated files when exiting the script.
+cleanup() {
+    EXIT_CODE=$?
+    set +e
+    if [[ -n "${TMP_DIR}" ]]; then
+        echo "Executing cleanup of tmp files"
+        rm -Rf "${TMP_DIR}"
+    fi
+    exit $EXIT_CODE
+}
+trap cleanup EXIT
+
+
+echo "Installing CMake..."
+apt-get -y purge --auto-remove cmake
+mkdir -p /opt/cmake
+
+architecture=$(dpkg --print-architecture)
+case "${architecture}" in
+    arm64)
+        ARCH=aarch64 ;;
+    amd64)
+        ARCH=x86_64 ;;
+    *)
+        echo "Unsupported architecture ${architecture}."
+        exit 1
+        ;;
+esac
+
+CMAKE_BINARY_NAME="cmake-${CMAKE_VERSION}-linux-${ARCH}.sh"
+CMAKE_CHECKSUM_NAME="cmake-${CMAKE_VERSION}-SHA-256.txt"
+TMP_DIR=$(mktemp -d -t cmake-XXXXXXXXXX)
+
+echo "${TMP_DIR}"
+cd "${TMP_DIR}"
+
+curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${CMAKE_BINARY_NAME}" -O
+curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${CMAKE_CHECKSUM_NAME}" -O
+
+sha256sum -c --ignore-missing "${CMAKE_CHECKSUM_NAME}"
+sh "${TMP_DIR}/${CMAKE_BINARY_NAME}" --prefix=/opt/cmake --skip-license
+
+ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake
+ln -s /opt/cmake/bin/ctest /usr/local/bin/ctest

--- a/.github/workflows/cpp.yaml
+++ b/.github/workflows/cpp.yaml
@@ -1,0 +1,54 @@
+name: C/C++ CI
+
+on:
+  push:
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      
+      - name: Get CMake
+        uses: lukka/get-cmake@latest
+
+      - name: vcpkg build
+        uses: johnwason/vcpkg-action@v5
+        with:
+          manifest-dir: ${{ github.workspace }} # Set to directory containing vcpkg.json
+          triplet: x64-linux
+          token: ${{ github.token }}
+
+      - name: Run CMake configure
+        run: |
+          cmake -DCMAKE_BUILD_TYPE=Release -H. -B${{ github.workspace }}/build -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/vcpkg/scripts/buildsystems/vcpkg.cmake
+
+      - name: Run CMake build
+        run: |
+          cmake --build ${{ github.workspace }}/build
+
+      - name: Cache build
+        uses: actions/cache@v3
+        with:
+          path: build
+          key: ${{ runner.os }}-build
+
+  tests:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Restore build cache
+        uses: actions/cache/restore@v3
+        with:
+          path: build
+          key: ${{ runner.os }}-build
+
+      - name: Run ctest
+        run: |
+          cd build
+          ctest -V --output-on-failure

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,14 @@
+{
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "release",
+      "binaryDir": "${sourceDir}/build",
+      "generator": "Ninja",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "CMAKE_BUILD_TYPE":"Release"
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -3,28 +3,35 @@
 The LAN7430 has the possibility to read its MAC address from a EEPROM. To achieve this the EEPROM content needs to be generated and written to the EEPROM.
 
 # Build
-To build the CLI tool and the library, you need a compiler that supports C++17
+To build the CLI tool and the library, you need a compiler that supports C++17. Prefer [vcpkg](https://vcpkg.io/en/) to install the dependencies.
 ## Dependencies
 CLI tool:
-* boost-system > 1.58.0 (system)
-* boost-filesystem > 1.58.0 (system)
 * spdlog (system/3rdparty)
 * cli11 (system/3rdparty)
 
 Library:
-* boost-system > 1.58.0 (system)
-* boost-filesystem > 1.58.0 (system)
 * spdlog (system/3rdparty)
 
 Tests:
-* boost-system > 1.58.0 (system)
-* boost-filesystem > 1.58.0 (system)
 * catch2 (3rdparty)
 * spdlog (system/3rdparty)
 
+## Build
+
+There are several ways to build the project. The easiest way is to use the provided CMakePresets.json with [vcpgk](https://vcpkg.io/en/).
+
+```sh
+# Make sure that vcpkg is installed and the environment variable VCPKG_ROOT is set
+echo $VCPKG_ROOT
+
+cmake --preset release
+cmake --build build
 ```
-mkdir build
-cmake -DCMAKE_BUILD_TYPE=Release -H. -Bbuild
+
+If you want to build the project without vcpkg, you need to install the dependencies manually or use the provided 3dparty folder.
+
+```sh
+cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -H.
 cmake --build build
 ```
 
@@ -157,3 +164,5 @@ There seems to be no checksum to verify the EEPROM content the only difference b
  00000020  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
  *
 ```
+# Development
+We recommend to use the [devcontainer](https://code.visualstudio.com/docs/devcontainers/containers) to have a consistent development environment. Otherwise you need to install the dependencies manually (see [Dependencies](#dependencies) / [Build](#build-1)).

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,3 @@
-find_package(Boost 1.58.0 COMPONENTS system filesystem REQUIRED)
 add_subdirectory(3rdparty/catch2)
 find_package(spdlog QUIET)
 find_package(CLI11 QUIET)
@@ -41,7 +40,6 @@ target_include_directories(${PROJECT_NAME}
 target_link_libraries(
     ${PROJECT_NAME}
     PRIVATE
-        ${Boost_LIBRARIES}
         spdlog::spdlog
         CLI11::CLI11
         lan7430-config-lib

--- a/src/include/validators.hpp
+++ b/src/include/validators.hpp
@@ -7,7 +7,7 @@ See accompanied file licence.txt for license information.
 #ifndef VALIDATORS_HPP
 #define VALIDATORS_HPP
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 #if __has_include(<cli11/CLI11.hpp>)
 #include <cli11/CLI11.hpp>
@@ -28,8 +28,8 @@ public:
     : Validator("DIR")
     {
         func_ = [](std::string& filePath) {
-            boost::filesystem::path path(filePath);
-            if (path.has_parent_path() && !boost::filesystem::exists(path.remove_filename()))
+            std::filesystem::path path(filePath);
+            if (path.has_parent_path() && !std::filesystem::exists(path.remove_filename()))
             {
                 return "Path does not exist: " + path.remove_filename().string();
             }

--- a/src/lan7430-config.cpp
+++ b/src/lan7430-config.cpp
@@ -4,7 +4,7 @@
 #include <lan7430conf/errors.hpp>
 #include <lan7430conf/lan7430conf.hpp>
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 #if __has_include(<cli11/CLI11.hpp>)
 #include <cli11/CLI11.hpp>
@@ -94,7 +94,7 @@ int main(int argc, char const* argv[])
             EEPROM eeprom = readEEPROM(configParams.inputPath);
             config = eepromConfigToEEPROM(eeprom);
         }
-        else if (boost::filesystem::exists(configParams.outputPath))
+        else if (std::filesystem::exists(configParams.outputPath))
         {
             EEPROM eeprom = readEEPROM(configParams.outputPath);
             config = eepromConfigToEEPROM(eeprom);

--- a/src/lib/lan7430conf/CMakeLists.txt
+++ b/src/lib/lan7430conf/CMakeLists.txt
@@ -24,7 +24,6 @@ generate_export_header(${PROJECT_NAME}
 )
 target_link_libraries(${PROJECT_NAME}
     PRIVATE
-        ${Boost_LIBRARIES}
         spdlog::spdlog
 )
 

--- a/src/lib/lan7430conf/test/020-testWriteEeprom.cpp
+++ b/src/lib/lan7430conf/test/020-testWriteEeprom.cpp
@@ -14,7 +14,7 @@
 
 #include <catch2/catch.hpp>
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 #include <fstream>
 #include <iomanip>
@@ -95,7 +95,7 @@ TEST_CASE("compareAgainstFiles", "[WriteEEPROM]")
     for (const auto& [macString, eepromFilePath] : macStrings)
     {
         std::string tempFilePath
-            = boost::filesystem::temp_directory_path().append(macString + ".bin").string();
+            = std::filesystem::temp_directory_path().append(macString + ".bin").string();
         // std::string tempFilePath = "./" + macString + ".bin";
 
         EEPROM_CONFIG config;
@@ -134,7 +134,7 @@ TEST_CASE("testWriteDefaultFiles", "[WriteEEPROM]")
 {
     for (const auto& [eepromFilePath, eepromConfig] : gs_testFilesVector)
     {
-        std::string tempFilePath = boost::filesystem::temp_directory_path()
+        std::string tempFilePath = std::filesystem::temp_directory_path()
                                        .append(macToString(eepromConfig.mac) + ".bin")
                                        .string();
         // std::string tempFilePath = "./" + macToString(eepromConfig.mac) + ".bin";
@@ -142,9 +142,9 @@ TEST_CASE("testWriteDefaultFiles", "[WriteEEPROM]")
         REQUIRE_NOTHROW(writeEEPROM(tempFilePath, eepromConfig));
 
         // compare the contents of the "files"
-        std::ifstream file_orig(boost::filesystem::absolute(eepromFilePath).string(),
+        std::ifstream file_orig(std::filesystem::absolute(eepromFilePath).string(),
                                 std::ifstream::binary | std::ifstream::ate);
-        std::ifstream file_new(boost::filesystem::absolute(tempFilePath).string(),
+        std::ifstream file_new(std::filesystem::absolute(tempFilePath).string(),
                                std::ifstream::binary | std::ifstream::ate);
         std::array<unsigned char, eeprom_user_defined_size> file_content_orig{};
         std::array<unsigned char, eeprom_user_defined_size> file_content_new{};

--- a/src/lib/lan7430conf/test/CMakeLists.txt
+++ b/src/lib/lan7430conf/test/CMakeLists.txt
@@ -28,7 +28,6 @@ set(TEST_FILES
 
 add_executable(${PROJECT_NAME} ${SOURCES})
 target_link_libraries(${PROJECT_NAME}
-    ${Boost_LIBRARIES}
     spdlog::spdlog
     catch2
     lan7430-config-lib

--- a/src/lib/lan7430conf/test/CMakeLists.txt
+++ b/src/lib/lan7430conf/test/CMakeLists.txt
@@ -16,6 +16,14 @@ set(TEST_FILES
     files/00-02-01-23-10-56-pad.bin
     files/00-02-01-23-10-57-pad.bin
     files/00-02-01-23-10-58-pad.bin
+    files/00-80-0F-74-30-01-default.bin
+    files/00-80-0F-74-30-01-default_DevId.bin
+    files/00-80-0F-74-30-01-default_DevId_OTP.bin
+    files/00-80-0F-74-30-01-default_MAC.bin
+    files/00-80-0F-74-30-01-L1_substates_all_on.bin
+    files/00-80-0F-74-30-01-L1_substates_off.bin
+    files/00-80-0F-74-30-01-L1_substates_on.bin
+    files/00-80-0F-74-30-01-random.bin
 )
 
 add_executable(${PROJECT_NAME} ${SOURCES})

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,14 @@
+{
+  "default-registry": {
+    "kind": "git",
+    "baseline": "4b2d315482086d487565287eed618aaff8b49c31",
+    "repository": "https://github.com/microsoft/vcpkg"
+  },
+  "registries": [
+    {
+      "kind": "artifact",
+      "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
+      "name": "microsoft"
+    }
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,11 +1,8 @@
 {
   "dependencies": [
-    "boost-filesystem",
-    "boost-system",
     "catch2",
     "cli11",
-    "spdlog",
-    "boost-endian"
+    "spdlog"
   ],
   "overrides": [
     {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,6 +8,14 @@
     {
       "name": "catch2",
       "version": "2.13.9"
+    },
+    {
+      "name": "cli11",
+      "version": "1.8.0"
+    },
+    {
+      "name": "spdlog",
+      "version": "1.12.0"
     }
   ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,16 @@
+{
+  "dependencies": [
+    "boost-filesystem",
+    "boost-system",
+    "catch2",
+    "cli11",
+    "spdlog",
+    "boost-endian"
+  ],
+  "overrides": [
+    {
+      "name": "catch2",
+      "version": "2.13.9"
+    }
+  ]
+}


### PR DESCRIPTION
- Fixed tests
- Added github workflow to run the tests
- Replaced the boost dependencies with native functions.
- Added the option to manage the dependencies via vcpk 
- Added .devcontainer for vscode / github codespace